### PR TITLE
Updated Uhh to created on stack and not on the heap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 # set the project name
-project(uhh VERSION 1.0)
+project(uhh VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 17)

--- a/src/setup/setup.cpp
+++ b/src/setup/setup.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include "git2.h"
 #include "git2/credential.h"

--- a/src/setup/setup.h
+++ b/src/setup/setup.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <fstream>
 #include <string>
 
 struct UhhOpts {
@@ -16,7 +15,6 @@ struct UhhConfig {
 class Uhh {
     public:
         Uhh(UhhOpts& opts);
-        ~Uhh();
 
         void addCommand(const std::string& tag, const std::string& cmd, const std::string& note);
         void find(const std::string& tag, const std::string& needle = "");

--- a/src/uhh.cpp
+++ b/src/uhh.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
         cmd
     };
 
-    Uhh* uhh = new Uhh(opts);
+    Uhh uhh{opts};
 
     if (cmd.compare("add") == 0) {
         std::string tag, cmd, note;
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
         std::cout << "What is the note? ";
         std::getline(std::cin, note);
 
-        uhh->addCommand(tag, cmd, note);
+        uhh.addCommand(tag, cmd, note);
     } else {
         std::stringstream str;
         int i = argc - 2;
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
             }
         }
 
-        uhh->find(cmd, str.str());
+        uhh.find(cmd, str.str());
     }
 
     return 0;


### PR DESCRIPTION
Changed `Uhh` class to be stack allocated.

Modern C++ idioms suggest keeping objects on stack as much as possible and let RAII do memory management for the user. The stl classes `std::unique_ptr` and `std::shared_ptr` are suggested for objects whose lifetime is longer than the creation scope.

Impact of this change: none.

------
