### PR TITLE
Added uhh2, config impl, and new uhh skeleton

### DIFF
--- a/cmd/uhh2/cli.go
+++ b/cmd/uhh2/cli.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/theprimeagen/uhh"
+	"github.com/urfave/cli"
+)
+
+type uhhCli struct {
+	backend *uhh.Uhh
+}
+
+func newUhhCli(backend *uhh.Uhh) *uhhCli {
+	return &uhhCli{
+		backend: backend,
+	}
+}
+
+func (ucli *uhhCli) findHandler(c *cli.Context) error {
+	if c.Args().Present() {
+		results := ucli.backend.Find(c.Args().First(), c.Args().Tail())
+		for _, r := range results {
+			fmt.Printf("%s - %s\n", r.Name, strings.Join(r.Terms, ", "))
+		}
+		return nil
+	}
+	cli.ShowAppHelp(c)
+	return nil
+}
+
+func (ucli *uhhCli) addHandler(c *cli.Context) error {
+	fmt.Println("add command")
+	cmd := readTermLine()
+	fmt.Println("please enter comma separated search terms")
+	jointTerms := readTermLine()
+
+	terms := strings.Split(jointTerms, ",")
+
+	err := ucli.backend.Add(cmd, terms)
+	if err != nil {
+		log.Fatal("unable to add command:", err)
+	}
+	return nil
+}
+
+func (ucli *uhhCli) deleteHandler(c *cli.Context) error {
+	return nil
+}

--- a/cmd/uhh2/config.go
+++ b/cmd/uhh2/config.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/theprimeagen/uhh"
+)
+
+func getConfig() *uhh.Config {
+	cfg, err := uhh.ReadUserConfig()
+	if err == uhh.ErrCfgNotFound {
+		cfg = readNewConfig()
+		path, err := uhh.DefaultConfigPath()
+		if err != nil {
+			log.Fatal("getting default path for config failed", err)
+		}
+		cfg.Write(path)
+	}
+
+	return cfg
+}
+
+func readNewConfig() *uhh.Config {
+	fmt.Println("Before Uhh can work, you need to provide a repo to save to!")
+	fmt.Println("Please enter your repo meow: ")
+
+	repoURL := readTermLine()
+
+	defaultCfg, err := uhh.DefaultConfigPath()
+	if err != nil {
+		log.Fatal("unable to get default config path:", err)
+	}
+	return uhh.CreateConfig(defaultCfg, repoURL)
+}
+
+func cloneConfigRepo(c *uhh.Config) bool {
+	if exists, shouldUpdate := checkLocalRepo(c.LocalRepoPath()); exists {
+		if shouldUpdate {
+			return gitFetch(c)
+		}
+		return true
+	}
+	return gitClone(c)
+}
+
+// we only say if we should update the repo every 6 hours
+// todo: make this configurable?
+func checkLocalRepo(path string) (exists bool, shouldUpdate bool) {
+	finfo, err := os.Stat(path)
+	if err != nil {
+		return os.IsExist(err), false
+	}
+	shouldUpdate = finfo.ModTime().Before(time.Now().Add(-6 * time.Hour))
+	return true, shouldUpdate
+}
+
+func gitFetch(c *uhh.Config) bool {
+	cmd := exec.Command("git", "-C", c.LocalRepoPath(), "fetch")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Run()
+	return cmd.ProcessState.Success()
+
+}
+func gitClone(c *uhh.Config) bool {
+	cmd := exec.Command("git", "clone", c.Repo(), c.LocalRepoPath())
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Run()
+	return cmd.ProcessState.Success()
+}

--- a/cmd/uhh2/main.go
+++ b/cmd/uhh2/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/theprimeagen/uhh"
+	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func main() {
+	cfg := getConfig()
+	if !cloneConfigRepo(cfg) {
+		log.Fatal("unable to get config")
+	}
+
+	uhh := uhh.New(cfg)
+	ucli := newUhhCli(uhh)
+
+	app := &cli.App{
+		Name:   "uhh",
+		Usage:  "find commands from your repo",
+		Action: ucli.findHandler,
+		Commands: []cli.Command{
+			{Name: "add", Action: ucli.addHandler},
+			{Name: "delete", Action: ucli.deleteHandler},
+		},
+	}
+	app.Run(os.Args)
+}
+
+func readTermLine() string {
+	oldState, err := terminal.MakeRaw(0)
+	if err != nil {
+		log.Fatal("could not change state of terminal")
+	}
+	defer terminal.Restore(0, oldState)
+	t := terminal.NewTerminal(os.Stdin, ">")
+
+	line, err := t.ReadLine()
+	if err != nil {
+		log.Fatal("unable to read line")
+	}
+	return line
+}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,134 @@
+package uhh
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+const repoKey = "repo"
+
+var (
+	ErrCfgNotFound     = fmt.Errorf("config file not found")
+	ErrRepoCfgNotFound = fmt.Errorf("repo url not found in config")
+)
+
+type Config struct {
+	basePath      string
+	configPath    string
+	localRepoPath string
+	vals          map[string]string
+}
+
+func DefaultConfigPath() (string, error) {
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("can'd find the default home dir: %w", err)
+	}
+
+	basePath := path.Join(cfgDir, "uhh")
+
+	err = os.MkdirAll(cfgDir, os.ModePerm)
+	if err != nil {
+		return "", fmt.Errorf("unable to create uhh config dir '%s': %w", basePath, err)
+	}
+
+	return path.Join(basePath, ".config"), nil
+}
+
+func ReadUserConfig() (*Config, error) {
+	cfgPath, err := DefaultConfigPath()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get default config path: %w", err)
+	}
+	return ReadConfig(cfgPath)
+}
+
+func ReadConfig(configPath string) (*Config, error) {
+	rawConfig, err := ioutil.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return nil, ErrCfgNotFound
+	}
+
+	values := parseConfig(string(rawConfig))
+
+	if _, ok := values[repoKey]; !ok {
+		return nil, ErrRepoCfgNotFound
+	}
+
+	basePath := path.Dir(configPath)
+	localRepoPath := path.Join(basePath, "repo")
+
+	return &Config{
+		basePath:      basePath,
+		configPath:    configPath,
+		localRepoPath: localRepoPath,
+		vals:          values,
+	}, nil
+}
+
+func parseConfig(cfg string) map[string]string {
+	lines := strings.Split(cfg, "\n")
+
+	cfgMap := map[string]string{}
+	for _, l := range lines {
+		kv := strings.SplitN(l, "=", 2)
+		if len(kv) == 2 {
+			cfgMap[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		}
+	}
+
+	return cfgMap
+}
+
+func CreateConfig(configPath, repo string) *Config {
+	basePath := path.Dir(configPath)
+	localRepoPath := path.Join(basePath, "repo")
+
+	return &Config{
+		configPath:    configPath,
+		basePath:      basePath,
+		localRepoPath: localRepoPath,
+		vals:          map[string]string{repoKey: repo},
+	}
+}
+
+func (c *Config) Keys() []string {
+	keys := []string{}
+	for k := range c.vals {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (c *Config) Value(k string) (string, bool) {
+	v, ok := c.vals[k]
+	return v, ok
+}
+
+func (c *Config) Repo() string {
+	return c.vals[repoKey]
+}
+
+func (c *Config) LocalRepoPath() string {
+	return c.localRepoPath
+}
+
+func (c *Config) Path() string {
+	return c.configPath
+}
+
+func (c *Config) Write(path string) error {
+	data := c.serialize()
+	return ioutil.WriteFile(path, data, os.ModePerm)
+}
+
+func (c *Config) serialize() []byte {
+	var out strings.Builder
+	for k, v := range c.vals {
+		out.WriteString(k + "=" + v + "\n")
+	}
+	return []byte(out.String())
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,78 @@
+package uhh
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestReadConfig(t *testing.T) {
+	cfgStr := `
+	repo=https://github.com/theprimagen/uhh
+	`
+	f, closer, err := createTempCfg(cfgStr)
+	defer closer()
+	if err != nil {
+		t.Error("unable to create temp file", err)
+	}
+	cfg, err := ReadConfig(f.Name())
+
+	if err != nil {
+		t.Error("un expected error")
+	}
+
+	if cfg.Repo() != "https://github.com/theprimagen/uhh" {
+		t.Error("repo method returned unexpected value")
+	}
+}
+
+func TestReadConfigWithoutRepo(t *testing.T) {
+	cfgStr := `
+	git=https://github.com/theprimagen/uhh
+	`
+	f, closer, err := createTempCfg(cfgStr)
+	defer closer()
+	if err != nil {
+		t.Error("unable to create temp file", err)
+	}
+
+	cfg, err := ReadConfig(f.Name())
+	if err != ErrRepoCfgNotFound {
+		t.Error("expected reading config to fail with repo key not found but got", cfg, err)
+	}
+}
+
+func createTempCfg(str string) (*os.File, func(), error) {
+	f, err := ioutil.TempFile("", "without-repo")
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	f.WriteString(str)
+
+	return f, func() { os.Remove(f.Name()) }, err
+}
+func TestConfigParser(t *testing.T) {
+	inputs := []struct {
+		name     string
+		raw      string
+		expected map[string]string
+	}{
+		{"positive test", "repo=https://github.com/theprimeagen/uhh-cfg", map[string]string{"repo": "https://github.com/theprimeagen/uhh-cfg"}},
+		{"empty string parse", "", map[string]string{}},
+		{"no equals sign", "this is a useless line", map[string]string{}},
+		{"multiple equals signs", "woah=dude=where=is=my=car", map[string]string{"woah": "dude=where=is=my=car"}},
+		{"space is ignored", "key = value", map[string]string{"key": "value"}},
+	}
+
+	for i := range inputs {
+		tcase := inputs[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			result := parseConfig(tcase.raw)
+			if !reflect.DeepEqual(tcase.expected, result) {
+				t.Errorf("parse result did not match for %s: expected: %+v, got: %+v", tcase.name, tcase.expected, result)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/theprimeagen/uhh
 
 go 1.12
 
-require golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
+require (
+	github.com/urfave/cli v1.22.4
+	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/theprimeagen/uhh v0.0.0-20200416004948-b30e4ca91c21 h1:VnpA3TdnwnN7feIdiSETNPcKxeg1g97KH93WTDBnTQo=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5 h1:Q7tZBpemrlsc2I7IyODzhtallWRSm4Q0d09pL6XbQtU=
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -7,3 +17,5 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/uhh.go
+++ b/uhh.go
@@ -1,0 +1,48 @@
+package uhh
+
+import "fmt"
+
+type Uhh struct {
+	entries []*CmdEntry
+}
+
+func New(cfg *Config) *Uhh {
+	return &Uhh{
+		entries: []*CmdEntry{
+			newEntry("hmm", "uhh"),
+			newEntry("rust", "yaya"),
+		},
+	}
+}
+
+func (u *Uhh) Find(tag string, desc []string) []*CmdEntry {
+	return u.entries
+}
+
+func (u *Uhh) Add(cmd string, searchTerms []string) error {
+	fmt.Println("adding command", cmd)
+	return fmt.Errorf("not implemented")
+}
+func (u *Uhh) Delete(entry *CmdEntry) error {
+	if entry.line == -1 || entry.file == "<mem>" {
+		return fmt.Errorf("remove demo entries and point to file line location")
+	}
+	return fmt.Errorf("not implemented")
+}
+
+type CmdEntry struct {
+	Name  string
+	Terms []string
+
+	line int
+	file string
+}
+
+func newEntry(name string, terms ...string) *CmdEntry {
+	return &CmdEntry{
+		Name:  name,
+		Terms: terms,
+		file:  "<mem>",
+		line:  -1,
+	}
+}


### PR DESCRIPTION
Changes in Pull Request:
* New config parser: this is complete (as complete as previous implementation)
* New Uhh backend skeleton:
  * the new Uhh is independent of console io, it only exposes which can be imported by other binaries if needed. (uhh web app for example)
   * for interactive search, loading the backend once during init would be faster
  * the implementation is left empty for stream content
* Added new cmd `uhh2`: 
  * uses the new skeleton
  * uses cli lib for handling commands
    * the cli lib has (Bash|ZSH) completion generation functionality, maybe helpful in the future
  * has fixed git clone/fetch
  * only updates the repo once in 6 hours 

git repo management might become a possible problem in the future, if the add commands are being issued from multiple machines.

-----
The previous implementation is intact and can be removed when the existing logic is ported to the new Uhh.

----
No docs because the code is the documentation 😇
